### PR TITLE
Added disconnect button

### DIFF
--- a/app/src/main/res/menu/menu_disconnect.xml
+++ b/app/src/main/res/menu/menu_disconnect.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/disconnect"
+        android:title="@string/disconnect_button"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Heart rate monitor</string>
     <string name="scan_button">Scan</string>
+    <string name="disconnect_button">Disconnect</string>
     <string name="no_data">xx</string>
     <string name="no_battery_level">-- %</string>
     <string name="battery_icon">battery icon</string>


### PR DESCRIPTION
Can now go back and forth from scanning activity to device acitity.

Also put fix for status 133: "To get around this issue, just make sure you run any BLE interaction code (device#connectGatt, connect, disconnect, etc) code in the UIThread (with a handler, local service, or Activity#runOnUiThread). Follow this rule of thumb and you will hopefully avoid this dreadful problem."

https://stackoverflow.com/questions/20069507/gatt-callback-fails-to-register